### PR TITLE
Child container support

### DIFF
--- a/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_disposing_the_builder.cs
+++ b/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_disposing_the_builder.cs
@@ -53,8 +53,6 @@ namespace NServiceBus.ContainerTests
                 Assert.False(AnotherSingletonComponent.DisposeCalled, "Dispose should not be called on AnotherSingletonComponent because it belongs to main container");
                 Assert.True(DisposableComponent.DisposeCalled, "Dispose should be called on DisposableComponent");
             }
-
-            //Not supported by, typeof(SpringObjectBuilder));
         }
 
         public class DisposableComponent : IDisposable

--- a/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_disposing_the_builder.cs
+++ b/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_disposing_the_builder.cs
@@ -36,7 +36,6 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        [Ignore("Not supported in Spring")]
         public void Should_dispose_all_IDisposable_components_in_child_container()
         {
             using (var main = TestContainerBuilder.ConstructBuilder())

--- a/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_registering_components.cs
+++ b/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_registering_components.cs
@@ -35,7 +35,6 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        [Ignore("Not supported in Spring")]
         public void A_registration_should_be_allowed_to_be_updated()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
@@ -45,8 +44,18 @@ namespace NServiceBus.ContainerTests
 
                 Assert.IsInstanceOf<AnotherSingletonComponent>(builder.Build(typeof(ISingletonComponent)));
             }
+        }
 
-            //Not supported by, typeof(SpringObjectBuilder));
+        [Test]
+        public void A_registration_should_be_allowed_to_be_updated_for_func_factories()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure<ISingletonComponent>(() => new SingletonComponent(), DependencyLifecycle.SingleInstance);
+                builder.Configure<ISingletonComponent>(() => new AnotherSingletonComponent(), DependencyLifecycle.SingleInstance);
+
+                Assert.IsInstanceOf<AnotherSingletonComponent>(builder.Build(typeof(ISingletonComponent)));
+            }
         }
 
         [Test]

--- a/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_registering_components.cs
+++ b/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_registering_components.cs
@@ -206,7 +206,6 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        [Ignore("Not supported in Spring")]
         public void All_implemented_interfaces_should_be_registered_for_func()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
@@ -218,8 +217,6 @@ namespace NServiceBus.ContainerTests
                 Assert.True(builder.HasComponent(typeof(IYetAnotherInterface)));
                 Assert.AreEqual(1, builder.BuildAll(typeof(IYetAnotherInterface)).Count());
             }
-
-            //Not supported bytypeof(SpringObjectBuilder));
         }
 
         [Test]

--- a/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_using_nested_containers.cs
+++ b/src/NServiceBus.Spring.Tests/App_Packages/NSB.ContainerTests.5.0.0/When_using_nested_containers.cs
@@ -11,7 +11,6 @@ namespace NServiceBus.ContainerTests
     {
 
         [Test]
-        [Ignore("Not supported in Spring")]
         public void Instance_per_uow__components_should_be_disposed_when_the_child_container_is_disposed()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
@@ -22,11 +21,9 @@ namespace NServiceBus.ContainerTests
                     nestedContainer.Build(typeof(InstancePerUoWComponent));
                 Assert.True(InstancePerUoWComponent.DisposeCalled);
             }
-            //Not supported bytypeof(SpringObjectBuilder));
         }
 
         [Test]
-        [Ignore("Not supported in Spring")]
         public void Instance_per_uow__components_should_not_be_shared_across_child_containers()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
@@ -50,9 +47,6 @@ namespace NServiceBus.ContainerTests
                 });
                 Assert.AreNotSame(task1.Result, task2.Result);
             }
-
-
-            //Not supported bytypeof(SpringObjectBuilder));
         }
 
         [Test]
@@ -114,7 +108,6 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        [Ignore("Not supported in Spring")]
         public void UoW_components_in_the_parent_container_should_be_singletons_in_the_child_container()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
@@ -126,7 +119,6 @@ namespace NServiceBus.ContainerTests
                     Assert.AreSame(nestedContainer.Build(typeof(InstancePerUoWComponent)), nestedContainer.Build(typeof(InstancePerUoWComponent)), "UoW's should be singleton in child container");
                 }
             }
-            //Not supported bytypeof(SpringObjectBuilder));
         }
 
         [Test]
@@ -164,7 +156,6 @@ namespace NServiceBus.ContainerTests
                 }
                 Assert.False(SingletonComponent.DisposeCalled);
             }
-            //Not supported by typeof(SpringObjectBuilder));
         }
 
         class SingletonComponent : ISingletonComponent, IDisposable

--- a/src/NServiceBus.Spring.Tests/NServiceBus.Spring.Tests.csproj
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.Spring.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_releasing_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_using_nested_containers.cs" />
     <Compile Include="SetUpFixture.cs" />
+    <Compile Include="When_using_nested_containers_including_reconfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NServiceBus.Spring.Tests/When_using_nested_containers_including_reconfiguration.cs
+++ b/src/NServiceBus.Spring.Tests/When_using_nested_containers_including_reconfiguration.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.Spring.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.ContainerTests;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_using_nested_containers_including_reconfiguration
+    {
+        [Test]
+        public void it_just_works()
+        {
+            ConventionalBusDependency.DisposeCalled = 0;
+            ConventionalBusDependency.InstanceCounter = 0;
+
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(typeof(RealBus), DependencyLifecycle.SingleInstance);
+                var outerBus = builder.Build(typeof(IRealBus));
+
+                Assert.IsInstanceOf<RealBus>(outerBus);
+
+                var t1 = Task.Run(() =>
+                {
+                    using (var nestedContainer = builder.BuildChildContainer())
+                    {
+                        nestedContainer.Configure(typeof(ConventionalBusDependency), DependencyLifecycle.InstancePerUnitOfWork);
+                        nestedContainer.Configure(typeof(ConventionalBus), DependencyLifecycle.InstancePerUnitOfWork);
+
+                        var bus1 = nestedContainer.Build(typeof(IRealBus));
+                        var bus2 = nestedContainer.Build(typeof(IRealBus));
+
+                        Assert.IsInstanceOf<ConventionalBus>(bus1);
+                        Assert.IsInstanceOf<ConventionalBus>(bus2);
+
+                        Assert.AreSame(bus1, bus2);
+                    }
+                });
+
+                var t2 = Task.Run(() =>
+                {
+                    using (var nestedContainer = builder.BuildChildContainer())
+                    {
+                        nestedContainer.Configure(typeof(ConventionalBusDependency), DependencyLifecycle.InstancePerUnitOfWork);
+                        nestedContainer.Configure(typeof(ConventionalBus), DependencyLifecycle.InstancePerUnitOfWork);
+
+                        var bus1 = nestedContainer.Build(typeof(IRealBus));
+                        var bus2 = nestedContainer.Build(typeof(IRealBus));
+
+                        Assert.IsInstanceOf<ConventionalBus>(bus1);
+                        Assert.IsInstanceOf<ConventionalBus>(bus2);
+
+                        Assert.AreSame(bus1, bus2);
+                    }
+                });
+
+                Task.WaitAll(t1, t2);
+
+                Assert.AreEqual(2, ConventionalBusDependency.DisposeCalled);
+                Assert.AreEqual(2, ConventionalBusDependency.InstanceCounter);
+            }
+        }
+
+        interface IRealBus { }
+
+        class ConventionalBusDependency : IDisposable
+        {
+            public static int InstanceCounter;
+
+            public static int DisposeCalled;
+
+            public ConventionalBusDependency()
+            {
+                InstanceCounter++;
+            }
+
+            public void Dispose()
+            {
+                DisposeCalled++;
+            }
+        }
+        class RealBus : IRealBus { }
+
+        class ConventionalBus : IRealBus
+        {
+            // ReSharper disable once NotAccessedField.Local
+            readonly ConventionalBusDependency conventionalBusDependency;
+
+            public ConventionalBus(ConventionalBusDependency dependency)
+            {
+                conventionalBusDependency = dependency;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Spring/ChildContainerTypeRegistration.cs
+++ b/src/NServiceBus.Spring/ChildContainerTypeRegistration.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.ObjectBuilder.Spring
+{
+    using System;
+    using global::Spring.Objects.Factory.Config;
+    using global::Spring.Objects.Factory.Support;
+
+    class ChildContainerTypeRegistration : TypeRegistration
+    {
+        public ChildContainerTypeRegistration(Type componentType, ComponentConfig componentConfig, DependencyLifecycle dependencyLifecycle, IObjectDefinitionFactory definitionFactory)
+            : base(componentType, componentConfig, dependencyLifecycle, definitionFactory)
+        {
+        }
+
+        protected override ObjectDefinitionBuilder CreateBuilder()
+        {
+            return ObjectDefinitionBuilder.RootObjectDefinition(definitionFactory, componentType)
+                .SetAutowireMode(AutoWiringMode.AutoDetect)
+                .SetSingleton(true);
+        }
+    }
+}

--- a/src/NServiceBus.Spring/ComponentFactoryRegistration.cs
+++ b/src/NServiceBus.Spring/ComponentFactoryRegistration.cs
@@ -1,0 +1,31 @@
+﻿namespace NServiceBus.ObjectBuilder.Spring
+{
+    using System;
+    using global::Spring.Context.Support;
+
+    class ComponentFactoryRegistration<T> : RegisterAction
+    {
+        Func<T> componentFactory;
+        DependencyLifecycle dependencyLifecycle;
+
+        public ComponentFactoryRegistration(Func<T> componentFactory, DependencyLifecycle dependencyLifecycle)
+        {
+            this.dependencyLifecycle = dependencyLifecycle;
+            this.componentFactory = componentFactory;
+        }
+
+        public override bool ApplicableForChildContainer
+        {
+            get { return dependencyLifecycle == DependencyLifecycle.InstancePerUnitOfWork; }
+        }
+
+        public override void Register(GenericApplicationContext context)
+        {
+            var componentType = typeof(T);
+
+            var funcFactory = new ArbitraryFuncDelegatingFactoryObject<T>(componentFactory, dependencyLifecycle == DependencyLifecycle.SingleInstance);
+
+            context.ObjectFactory.RegisterSingleton(componentType.FullName, funcFactory);
+        }
+    }
+}

--- a/src/NServiceBus.Spring/NServiceBus.Spring.csproj
+++ b/src/NServiceBus.Spring/NServiceBus.Spring.csproj
@@ -75,11 +75,18 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArbitraryFuncDelegatingFactoryObject.cs" />
+    <Compile Include="ChildContainerTypeRegistration.cs" />
     <Compile Include="ComponentConfig.cs" />
+    <Compile Include="ComponentFactoryRegistration.cs" />
+    <Compile Include="RegisterAction.cs" />
+    <Compile Include="RootContainerTypeRegistration.cs" />
+    <Compile Include="SingletonRegistration.cs" />
     <Compile Include="SpringBuilder.cs" />
     <Compile Include="SpringExtensions.cs" />
     <Compile Include="SpringObjectBuilder.cs" />
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="TypeRegistration.cs" />
+    <Compile Include="TypeRegistrationDecorator.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml">

--- a/src/NServiceBus.Spring/NServiceBus.Spring.csproj
+++ b/src/NServiceBus.Spring/NServiceBus.Spring.csproj
@@ -86,7 +86,7 @@
     <Compile Include="SpringObjectBuilder.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="TypeRegistration.cs" />
-    <Compile Include="TypeRegistrationDecorator.cs" />
+    <Compile Include="TypeRegistrationProxy.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml">

--- a/src/NServiceBus.Spring/RegisterAction.cs
+++ b/src/NServiceBus.Spring/RegisterAction.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.ObjectBuilder.Spring
+{
+    using global::Spring.Context.Support;
+
+    abstract class RegisterAction
+    {
+        public abstract bool ApplicableForChildContainer { get; }
+
+        public abstract void Register(GenericApplicationContext context);
+    }
+}

--- a/src/NServiceBus.Spring/RootContainerTypeRegistration.cs
+++ b/src/NServiceBus.Spring/RootContainerTypeRegistration.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.ObjectBuilder.Spring
+{
+    using System;
+    using global::Spring.Objects.Factory.Config;
+    using global::Spring.Objects.Factory.Support;
+
+    class RootContainerTypeRegistration : TypeRegistration
+    {
+        public RootContainerTypeRegistration(Type componentType, ComponentConfig componentConfig, DependencyLifecycle dependencyLifecycle, IObjectDefinitionFactory definitionFactory)
+            : base(componentType, componentConfig, dependencyLifecycle, definitionFactory)
+        {
+        }
+
+        protected override ObjectDefinitionBuilder CreateBuilder()
+        {
+            return ObjectDefinitionBuilder.RootObjectDefinition(definitionFactory, componentType)
+                .SetAutowireMode(AutoWiringMode.AutoDetect)
+                .SetSingleton(dependencyLifecycle == DependencyLifecycle.SingleInstance);
+        }
+    }
+}

--- a/src/NServiceBus.Spring/SingletonRegistration.cs
+++ b/src/NServiceBus.Spring/SingletonRegistration.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.ObjectBuilder.Spring
+{
+    using System;
+    using global::Spring.Context.Support;
+
+    class SingletonRegistration : RegisterAction
+    {
+        readonly Type componentType;
+        readonly object instance;
+
+        public SingletonRegistration(Type componentType, object instance)
+        {
+            this.instance = instance;
+            this.componentType = componentType;
+        }
+
+        public override bool ApplicableForChildContainer
+        {
+            get { return false; }
+        }
+
+        public override void Register(GenericApplicationContext context)
+        {
+            context.ObjectFactory.RegisterSingleton(componentType.FullName, instance);
+        }
+    }
+}

--- a/src/NServiceBus.Spring/SpringObjectBuilder.cs
+++ b/src/NServiceBus.Spring/SpringObjectBuilder.cs
@@ -169,14 +169,18 @@
                 return;
             }
 
-            var isApplicableForChildContainerWhenChildContainerIsInitialized = isChildContainer ? (Func<RegisterAction, bool>) (r => r.ApplicableForChildContainer) : (r => true);
-            foreach (var action in new List<RegisterAction>(registrations.Values.Where(isApplicableForChildContainerWhenChildContainerIsInitialized)))
+            foreach (var action in new List<RegisterAction>(registrations.Values.Where(r => IsRootContainer || r.ApplicableForChildContainer)))
             {
                 action.Register(context);
             }
 
             initialized = true;
             context.Refresh();
+        }
+
+        bool IsRootContainer
+        {
+            get { return !isChildContainer; }
         }
 
         void ThrowIfAlreadyInitialized()

--- a/src/NServiceBus.Spring/SpringObjectBuilder.cs
+++ b/src/NServiceBus.Spring/SpringObjectBuilder.cs
@@ -117,7 +117,7 @@
                 componentProperties[concreteComponent] = new ComponentConfig();
             }
 
-            registrations[concreteComponent] = new TypeRegistrationDecorator(concreteComponent, componentProperties[concreteComponent], dependencyLifecycle, factory);
+            registrations[concreteComponent] = new TypeRegistrationProxy(concreteComponent, componentProperties[concreteComponent], dependencyLifecycle, factory);
         }
 
         public void Configure<T>(Func<T> componentFactory, DependencyLifecycle dependencyLifecycle)

--- a/src/NServiceBus.Spring/SpringObjectBuilder.cs
+++ b/src/NServiceBus.Spring/SpringObjectBuilder.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using Common;
     using global::Spring.Context.Support;

--- a/src/NServiceBus.Spring/TypeRegistration.cs
+++ b/src/NServiceBus.Spring/TypeRegistration.cs
@@ -1,0 +1,40 @@
+namespace NServiceBus.ObjectBuilder.Spring
+{
+    using System;
+    using global::Spring.Context.Support;
+    using global::Spring.Objects.Factory.Config;
+    using global::Spring.Objects.Factory.Support;
+
+    abstract class TypeRegistration : RegisterAction
+    {
+        protected readonly DependencyLifecycle dependencyLifecycle;
+        protected readonly Type componentType;
+        protected readonly IObjectDefinitionFactory definitionFactory;
+        readonly ComponentConfig componentConfig;
+
+        protected TypeRegistration(Type componentType, ComponentConfig componentConfig, DependencyLifecycle dependencyLifecycle, IObjectDefinitionFactory definitionFactory)
+        {
+            this.definitionFactory = definitionFactory;
+            this.componentConfig = componentConfig;
+            this.componentType = componentType;
+            this.dependencyLifecycle = dependencyLifecycle;
+        }
+
+        public override bool ApplicableForChildContainer
+        {
+            get { throw new InvalidOperationException("TypeRegistration ApplicableForChildContainer should never be called. The decision should is done in the TypeRegistrationDecorator"); }
+        }
+
+        public override void Register(GenericApplicationContext context)
+        {
+            var builder = CreateBuilder();
+
+            componentConfig.Configure(builder);
+
+            IObjectDefinition def = builder.ObjectDefinition;
+            context.RegisterObjectDefinition(componentType.FullName, def);
+        }
+
+        protected abstract ObjectDefinitionBuilder CreateBuilder();
+    }
+}

--- a/src/NServiceBus.Spring/TypeRegistrationDecorator.cs
+++ b/src/NServiceBus.Spring/TypeRegistrationDecorator.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.ObjectBuilder.Spring
+{
+    using System;
+    using global::Spring.Context.Support;
+    using global::Spring.Objects.Factory.Support;
+
+    class TypeRegistrationDecorator : RegisterAction
+    {
+        readonly DependencyLifecycle dependencyLifecycle;
+        readonly Type componentType;
+        readonly ComponentConfig componentConfig;
+        readonly IObjectDefinitionFactory definitionFactory;
+
+        public TypeRegistrationDecorator(Type componentType, ComponentConfig componentConfig, DependencyLifecycle dependencyLifecycle, IObjectDefinitionFactory definitionFactory)
+        {
+            this.definitionFactory = definitionFactory;
+            this.componentConfig = componentConfig;
+            this.componentType = componentType;
+            this.dependencyLifecycle = dependencyLifecycle;
+        }
+
+        public override bool ApplicableForChildContainer
+        {
+            get { return dependencyLifecycle == DependencyLifecycle.InstancePerUnitOfWork; }
+        }
+
+        public override void Register(GenericApplicationContext context)
+        {
+            var registerAction = context.Name.StartsWith("child_of_") ?
+                (RegisterAction)new ChildContainerTypeRegistration(componentType, componentConfig, dependencyLifecycle, definitionFactory) :
+                new RootContainerTypeRegistration(componentType, componentConfig, dependencyLifecycle, definitionFactory);
+
+            registerAction.Register(context);
+        }
+    }
+}

--- a/src/NServiceBus.Spring/TypeRegistrationProxy.cs
+++ b/src/NServiceBus.Spring/TypeRegistrationProxy.cs
@@ -4,14 +4,14 @@
     using global::Spring.Context.Support;
     using global::Spring.Objects.Factory.Support;
 
-    class TypeRegistrationDecorator : RegisterAction
+    class TypeRegistrationProxy : RegisterAction
     {
         readonly DependencyLifecycle dependencyLifecycle;
         readonly Type componentType;
         readonly ComponentConfig componentConfig;
         readonly IObjectDefinitionFactory definitionFactory;
 
-        public TypeRegistrationDecorator(Type componentType, ComponentConfig componentConfig, DependencyLifecycle dependencyLifecycle, IObjectDefinitionFactory definitionFactory)
+        public TypeRegistrationProxy(Type componentType, ComponentConfig componentConfig, DependencyLifecycle dependencyLifecycle, IObjectDefinitionFactory definitionFactory)
         {
             this.definitionFactory = definitionFactory;
             this.componentConfig = componentConfig;


### PR DESCRIPTION
This PR contains child container support for Spring and enables additional features which were previously not supported. As soon as it is merged the container tests in the core need to be updated to reflect that fact.

It also contains a refactoring which cleans up the responsibility mess (between registering and creating the definitions on the container)

@andreasohlund @SzymonPobiega can you guys please review?

Pss: Still not super happy with the RegisterAction and the child container check but I couldn't come up with a better approach in a reasonable time frame

By the way the container is also lock free now.