### PR TITLE
Externally owned context is no longer disposed

### DIFF
--- a/src/NServiceBus.Spring.AcceptanceTests/NServiceBus.Spring.AcceptanceTests.csproj
+++ b/src/NServiceBus.Spring.AcceptanceTests/NServiceBus.Spring.AcceptanceTests.csproj
@@ -31,6 +31,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-rc0001\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
@@ -41,6 +49,10 @@
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Spring.Core, Version=2.0.1.45000, Culture=neutral, PublicKeyToken=65e474d141e25e07, processorArchitecture=MSIL">
+      <HintPath>..\packages\Spring.Core.2.0.1\lib\net45\Spring.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -60,8 +72,10 @@
   <ItemGroup>
     <Compile Include="DefaultServer.cs" />
     <Compile Include="NServiceBusAcceptanceTest.cs" />
+    <Compile Include="SpecialGenericApplicationContext.cs" />
     <Compile Include="When_declaring_a_public_property.cs" />
     <Compile Include="When_setting_properties_explicitly_via_the_container.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NServiceBus.Spring.AcceptanceTests/SpecialGenericApplicationContext.cs
+++ b/src/NServiceBus.Spring.AcceptanceTests/SpecialGenericApplicationContext.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.Spring.AcceptanceTests
+{
+    using global::Spring.Context.Support;
+
+    class SpecialGenericApplicationContext : GenericApplicationContext
+    {
+        public bool Disposed { get; private set; }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            Disposed = true;
+        }
+    }
+}

--- a/src/NServiceBus.Spring.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Spring.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.Spring.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_shutdown_properly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.ApplicationContext.Disposed);
+            Assert.DoesNotThrow(() => context.ApplicationContext.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public SpecialGenericApplicationContext ApplicationContext { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, desc) =>
+                {
+                    var genericContext = new SpecialGenericApplicationContext();
+
+                    config.UseContainer<SpringBuilder>(c => c.ExistingApplicationContext(genericContext));
+
+                    var context = (Context) desc.ScenarioContext;
+                    context.ApplicationContext = genericContext;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Spring.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Spring.AcceptanceTests/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="3.0.0" targetFramework="net452" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="Spring.Core" version="2.0.1" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Spring.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Spring.Tests/DisposalTests.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.Spring.Tests
+{
+    using global::Spring.Context.Support;
+    using NUnit.Framework;
+    using ObjectBuilder.Spring;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeContainer = new SpecialGenericApplicationContext();
+
+            var container = new SpringObjectBuilder(fakeContainer, true);
+            container.Dispose();
+
+            Assert.True(fakeContainer.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeContainer = new SpecialGenericApplicationContext();
+
+            var container = new SpringObjectBuilder(fakeContainer, false);
+            container.Dispose();
+
+            Assert.False(fakeContainer.Disposed);
+        }
+
+        class SpecialGenericApplicationContext : GenericApplicationContext
+        {
+            public bool Disposed { get; private set; }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                Disposed = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Spring.Tests/NServiceBus.Spring.Tests.csproj
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.Spring.Tests.csproj
@@ -46,6 +46,14 @@
       <HintPath>..\packages\ApprovalUtilities.3.0.11\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
@@ -70,6 +78,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Spring.Core, Version=2.0.1.45000, Culture=neutral, PublicKeyToken=65e474d141e25e07, processorArchitecture=MSIL">
+      <HintPath>..\packages\Spring.Core.2.0.1\lib\net45\Spring.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -89,6 +101,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_querying_for_registered_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_using_nested_containers.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
     <Compile Include="When_using_nested_containers_including_reconfiguration.cs" />
   </ItemGroup>

--- a/src/NServiceBus.Spring.Tests/packages.config
+++ b/src/NServiceBus.Spring.Tests/packages.config
@@ -3,8 +3,11 @@
   <package id="ApiApprover" version="3.0.1" targetFramework="net452" />
   <package id="ApprovalTests" version="3.0.11" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.11" targetFramework="net452" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net452" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.ContainerTests.Sources" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="Spring.Core" version="2.0.1" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Spring/SpringBuilder.cs
+++ b/src/NServiceBus.Spring/SpringBuilder.cs
@@ -18,14 +18,24 @@ namespace NServiceBus
         /// <returns>The new container wrapper.</returns>
         public override IContainer CreateContainer(ReadOnlySettings settings)
         {
-            GenericApplicationContext existingContext;
+            ContextHolder contextHolder;
 
-            if (settings.TryGet("ExistingContext", out existingContext))
+            if (settings.TryGet(out contextHolder))
             {
-                return new SpringObjectBuilder(existingContext);
+                return new SpringObjectBuilder(contextHolder.ExistingContext);
             }
 
             return new SpringObjectBuilder();
+        }
+
+        internal class ContextHolder
+        {
+            public ContextHolder(GenericApplicationContext context)
+            {
+                ExistingContext = context;
+            }
+
+            public GenericApplicationContext ExistingContext { get; }
         }
     }
 }

--- a/src/NServiceBus.Spring/SpringExtensions.cs
+++ b/src/NServiceBus.Spring/SpringExtensions.cs
@@ -17,7 +17,7 @@
         [CLSCompliant(false)]
         public static void ExistingApplicationContext(this ContainerCustomizations customizations, GenericApplicationContext applicationContext)
         {
-            customizations.Settings.Set("ExistingContext", applicationContext);
+            customizations.Settings.Set<SpringBuilder.ContextHolder>(new SpringBuilder.ContextHolder(applicationContext));
         }
     }
 }

--- a/src/NServiceBus.Spring/SpringObjectBuilder.cs
+++ b/src/NServiceBus.Spring/SpringObjectBuilder.cs
@@ -10,12 +10,17 @@
 
     class SpringObjectBuilder : IContainer
     {
-        public SpringObjectBuilder() : this(new GenericApplicationContext())
+        public SpringObjectBuilder() : this(new GenericApplicationContext(), true)
         {
         }
 
-        public SpringObjectBuilder(GenericApplicationContext context)
+        public SpringObjectBuilder(GenericApplicationContext context) : this(context, false)
         {
+        }
+
+        public SpringObjectBuilder(GenericApplicationContext context, bool owned)
+        {
+            this.owned = owned;
             this.context = context;
         }
 
@@ -33,7 +38,7 @@
                 Name = $"child_of_{context.Name}"
             };
 
-            return new SpringObjectBuilder(childContext)
+            return new SpringObjectBuilder(childContext, true)
             {
                 isChildContainer = true,
                 registrations = registrations,
@@ -134,6 +139,10 @@
 
         void DisposeManaged()
         {
+            if (!owned)
+            {
+                return;
+            }
             context?.Dispose();
         }
 
@@ -167,5 +176,6 @@
         Dictionary<Type, RegisterAction> registrations = new Dictionary<Type, RegisterAction>();
         bool initialized;
         DefaultObjectDefinitionFactory factory = new DefaultObjectDefinitionFactory();
+        bool owned;
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

If a user passes us in a kernel instance we will not dispose the application context instance. We consider that instance externally owned. This is a behavior breaking change. 

I also had to remove the key access since the SettingsHolder automatically disposes settings values that implement `IDisposable`.
