### PR TITLE
Add obsolete warnings to NServiceBus.Spring for last major version.

### DIFF
--- a/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
@@ -2,17 +2,24 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Spring.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
-
 namespace NServiceBus
 {
-    
+    [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
+        "se see https://docs.particular.net/nservicebus/containers/#supported-containers " +
+        "for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
     public class SpringBuilder : NServiceBus.Container.ContainerDefinition
     {
         public SpringBuilder() { }
+        [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
+            "se see https://docs.particular.net/nservicebus/containers/#supported-containers " +
+            "for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         public override NServiceBus.ObjectBuilder.Common.IContainer CreateContainer(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     public class static SpringExtensions
     {
+        [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
+            "se see https://docs.particular.net/nservicebus/containers/#supported-containers " +
+            "for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         [System.CLSCompliantAttribute(false)]
         public static void ExistingApplicationContext(this NServiceBus.Container.ContainerCustomizations customizations, Spring.Context.Support.GenericApplicationContext applicationContext) { }
     }

--- a/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
@@ -5,21 +5,18 @@
 namespace NServiceBus
 {
     [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
-        "se see https://docs.particular.net/nservicebus/containers/#supported-containers " +
-        "for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+        "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
     public class SpringBuilder : NServiceBus.Container.ContainerDefinition
     {
         public SpringBuilder() { }
         [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
-            "se see https://docs.particular.net/nservicebus/containers/#supported-containers " +
-            "for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         public override NServiceBus.ObjectBuilder.Common.IContainer CreateContainer(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     public class static SpringExtensions
     {
         [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
-            "se see https://docs.particular.net/nservicebus/containers/#supported-containers " +
-            "for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         [System.CLSCompliantAttribute(false)]
         public static void ExistingApplicationContext(this NServiceBus.Container.ContainerCustomizations customizations, Spring.Context.Support.GenericApplicationContext applicationContext) { }
     }

--- a/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
@@ -5,6 +5,7 @@
 
 namespace NServiceBus
 {
+    
     [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
         "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
     public class SpringBuilder : NServiceBus.Container.ContainerDefinition

--- a/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.ObjectBuilder.Spring.approved.cs
@@ -2,21 +2,22 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Spring.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+
 namespace NServiceBus
 {
     [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
-        "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+        "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
     public class SpringBuilder : NServiceBus.Container.ContainerDefinition
     {
         public SpringBuilder() { }
         [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
-            "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
         public override NServiceBus.ObjectBuilder.Common.IContainer CreateContainer(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     public class static SpringExtensions
     {
         [ObsoleteExAttribute(Message="NServiceBus.Spring has been deprecated. Using another container is advised.  Plea" +
-            "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "se see the upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
         [System.CLSCompliantAttribute(false)]
         public static void ExistingApplicationContext(this NServiceBus.Container.ContainerCustomizations customizations, Spring.Context.Support.GenericApplicationContext applicationContext) { }
     }

--- a/src/NServiceBus.Spring.Tests/NServiceBus.Spring.Tests.csproj
+++ b/src/NServiceBus.Spring.Tests/NServiceBus.Spring.Tests.csproj
@@ -25,4 +25,7 @@
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="[7.0.0-*,8.0)" />
     <ProjectReference Include="..\NServiceBus.Spring\NServiceBus.Spring.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/src/NServiceBus.Spring/SpringBuilder.cs
+++ b/src/NServiceBus.Spring/SpringBuilder.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
     /// Spring Container
     /// </summary>
     [ObsoleteEx(Message = obsolete.Message,
-        TreatAsErrorFromVersion = "8.0")]
+        TreatAsErrorFromVersion = "9.0")]
     public class SpringBuilder : ContainerDefinition
     {
         /// <summary>
@@ -19,7 +19,7 @@ namespace NServiceBus
         /// <param name="settings">The settings to check if an existing container exists.</param>
         /// <returns>The new container wrapper.</returns>
         [ObsoleteEx(Message = obsolete.Message,
-            TreatAsErrorFromVersion = "8.0")]
+            TreatAsErrorFromVersion = "9.0")]
         public override IContainer CreateContainer(ReadOnlySettings settings)
         {
             ContextHolder contextHolder;

--- a/src/NServiceBus.Spring/SpringBuilder.cs
+++ b/src/NServiceBus.Spring/SpringBuilder.cs
@@ -9,6 +9,8 @@ namespace NServiceBus
     /// <summary>
     /// Spring Container
     /// </summary>
+    [ObsoleteEx(Message = obsolete.Message,
+        TreatAsErrorFromVersion = "8.0")]
     public class SpringBuilder : ContainerDefinition
     {
         /// <summary>
@@ -16,6 +18,8 @@ namespace NServiceBus
         /// </summary>
         /// <param name="settings">The settings to check if an existing container exists.</param>
         /// <returns>The new container wrapper.</returns>
+        [ObsoleteEx(Message = obsolete.Message,
+            TreatAsErrorFromVersion = "8.0")]
         public override IContainer CreateContainer(ReadOnlySettings settings)
         {
             ContextHolder contextHolder;

--- a/src/NServiceBus.Spring/SpringExtensions.cs
+++ b/src/NServiceBus.Spring/SpringExtensions.cs
@@ -15,6 +15,8 @@
         /// <param name="customizations"></param>
         /// <param name="applicationContext">The existing application context.</param>
         [CLSCompliant(false)]
+        [ObsoleteEx(Message = obsolete.Message,
+            TreatAsErrorFromVersion = "8.0")]
         public static void ExistingApplicationContext(this ContainerCustomizations customizations, GenericApplicationContext applicationContext)
         {
             customizations.Settings.Set<SpringBuilder.ContextHolder>(new SpringBuilder.ContextHolder(applicationContext));

--- a/src/NServiceBus.Spring/SpringExtensions.cs
+++ b/src/NServiceBus.Spring/SpringExtensions.cs
@@ -16,7 +16,7 @@
         /// <param name="applicationContext">The existing application context.</param>
         [CLSCompliant(false)]
         [ObsoleteEx(Message = obsolete.Message,
-            TreatAsErrorFromVersion = "8.0")]
+            TreatAsErrorFromVersion = "9.0")]
         public static void ExistingApplicationContext(this ContainerCustomizations customizations, GenericApplicationContext applicationContext)
         {
             customizations.Settings.Set<SpringBuilder.ContextHolder>(new SpringBuilder.ContextHolder(applicationContext));

--- a/src/NServiceBus.Spring/obsolete.cs
+++ b/src/NServiceBus.Spring/obsolete.cs
@@ -1,0 +1,7 @@
+﻿namespace NServiceBus
+{
+    class obsolete
+    {
+        internal const string Message = "NServiceBus.Spring has been deprecated. Using another container is advised.  Please see https://docs.particular.net/nservicebus/containers/#supported-containers for a list of supported containers.";
+    }
+}

--- a/src/NServiceBus.Spring/obsolete.cs
+++ b/src/NServiceBus.Spring/obsolete.cs
@@ -2,6 +2,6 @@
 {
     class obsolete
     {
-        internal const string Message = "NServiceBus.Spring has been deprecated. Using another container is advised.  Please see https://docs.particular.net/nservicebus/containers/#supported-containers for a list of supported containers.";
+        internal const string Message = "NServiceBus.Spring has been deprecated. Using another container is advised.  Please see the upgrade guide for a list of supported containers.";
     }
 }


### PR DESCRIPTION
The [last Nuget package release of Spring.Core](https://www.nuget.org/packages/Spring.Core/2.0.1) was 2015-04-14. Last commit to the [Spring.Net repo](https://github.com/spring-projects/spring-net) was 2016-11-11 with minor updates. There does not appear to be an effort to bring Spring.Net to .net standard support. The .Net Spring framework appears to be dead. We have discussed dropping support for Spring in the past, this PR would make it official.