### PR TITLE
Update to NServiceBus beta10

### DIFF
--- a/src/NServiceBus.Spring/NServiceBus.Spring.csproj
+++ b/src/NServiceBus.Spring/NServiceBus.Spring.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spring.Core" Version="[2.0.1, 3.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010, 8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />


### PR DESCRIPTION
beta10 contains a breaking change around the `AddStartupDiagnosticsSection` extension method, see https://github.com/Particular/NServiceBus/pull/5039/files and therefore needs to be recompiled against beta10.